### PR TITLE
Ssdt tests

### DIFF
--- a/src/SQLProvider.Runtime/Providers.MsSqlServer.Ssdt.fs
+++ b/src/SQLProvider.Runtime/Providers.MsSqlServer.Ssdt.fs
@@ -170,8 +170,8 @@ module MSSqlServerSsdt =
         match typeMappingsByName.TryFind dataType with
         | Some tm -> tm
         | None ->
-            match Map.tryFind dataType uddts with
-            | Some x -> tryFindMappingOrVariant uddts x
+            match Map.tryFind (UDDTName dataType) uddts with
+            | Some (UDDTInheritedType x) -> tryFindMappingOrVariant uddts x
             | None -> (typeMappingsByName.TryFind "SQL_VARIANT").Value
 
     let ssdtTableToTable (tbl: SsdtTable) =

--- a/src/SQLProvider.Runtime/Providers.MsSqlServer.Ssdt.fs
+++ b/src/SQLProvider.Runtime/Providers.MsSqlServer.Ssdt.fs
@@ -165,32 +165,32 @@ module MSSqlServerSsdt =
     let tryFindMapping (dataType: string) =
         typeMappingsByName.TryFind (dataType.ToUpper())
 
-    let tryFindMappingOrVariant (dataType: string) =
+    let rec tryFindMappingOrVariant (uddts: SsdtUserDefinedDataType list) (dataType: string) =
         match typeMappingsByName.TryFind (dataType.ToUpper()) with
         | Some tm -> tm
-        | None -> (typeMappingsByName.TryFind "SQL_VARIANT").Value
+        | None ->
+            match List.tryFind (fun x -> x.Name = dataType) uddts with
+            | Some x -> tryFindMappingOrVariant uddts x.Inheritance
+            | None -> (typeMappingsByName.TryFind "SQL_VARIANT").Value
 
     let ssdtTableToTable (tbl: SsdtTable) =
         { Schema = tbl.Schema ; Name = tbl.Name ; Type =  if tbl.IsView then "view" else "base table" }
 
-    let ssdtColumnToColumn (tbl: SsdtTable) (col: SsdtColumn) =
-        match tryFindMapping col.DataType with
-        | Some typeMapping ->
-            Some
-                { Column.Name = col.Name
-                  Column.TypeMapping = typeMapping
-                  Column.IsNullable = col.AllowNulls
-                  Column.IsPrimaryKey =
-                    tbl.PrimaryKey
-                    |> ValueOption.map (fun pk -> pk.Columns |> List.exists (fun pkCol -> pkCol.Name = col.Name))
-                    |> ValueOption.defaultValue false
-                  Column.IsAutonumber = col.IsIdentity
-                  Column.HasDefault = col.HasDefault
-                  Column.IsComputed = col.ComputedColumn
-                  Column.TypeInfo = if col.DataType = "" then ValueNone else ValueSome col.DataType }
-        | None ->
-            None
 
+    let ssdtColumnToColumn uddts (tbl: SsdtTable) (col: SsdtColumn) =
+        let typeMapping = tryFindMappingOrVariant uddts col.DataType
+        Some
+            { Column.Name = col.Name
+              Column.TypeMapping = typeMapping
+              Column.IsNullable = col.AllowNulls
+              Column.IsPrimaryKey =
+                tbl.PrimaryKey
+                |> ValueOption.map (fun pk -> pk.Columns |> List.exists (fun pkCol -> pkCol.Name = col.Name))
+                |> ValueOption.defaultValue false
+              Column.IsAutonumber = col.IsIdentity
+              Column.HasDefault = col.HasDefault
+              Column.IsComputed = col.ComputedColumn
+              Column.TypeInfo = if col.DataType = "" then ValueNone else ValueSome col.DataType }
 
 type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
     let schemaCache = SchemaCache.Empty
@@ -317,7 +317,7 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
                 match ssdtSchema.Value.TryGetTableByName(table.Name) with
                 | ValueSome ssdtTbl ->
                     ssdtTbl.Columns
-                    |> List.map (MSSqlServerSsdt.ssdtColumnToColumn ssdtTbl)
+                    |> List.map (MSSqlServerSsdt.ssdtColumnToColumn (ssdtSchema.Value.UserDefinedDataTypes) ssdtTbl)
                     |> List.choose id
                     |> List.map (fun col -> col.Name, col)
                 | ValueNone -> []
@@ -375,7 +375,7 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
                     sp.Parameters
                     |> List.mapi (fun idx p ->
                         { Name = p.Name
-                          TypeMapping = MSSqlServerSsdt.tryFindMappingOrVariant p.DataType
+                          TypeMapping = MSSqlServerSsdt.tryFindMappingOrVariant (ssdtSchema.Value.UserDefinedDataTypes) p.DataType
                           Direction = if p.IsOutput then ParameterDirection.InputOutput else ParameterDirection.Input
                           Length = p.Length
                           Ordinal = idx }
@@ -385,7 +385,7 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
                     |> List.filter (fun p -> p.IsOutput)
                     |> List.mapi (fun idx p ->
                         { Name = p.Name
-                          TypeMapping = MSSqlServerSsdt.tryFindMappingOrVariant p.DataType
+                          TypeMapping = MSSqlServerSsdt.tryFindMappingOrVariant (ssdtSchema.Value.UserDefinedDataTypes) p.DataType
                           Direction = ParameterDirection.InputOutput
                           Length = p.Length
                           Ordinal = idx }

--- a/src/SQLProvider.Runtime/Providers.MsSqlServer.Ssdt.fs
+++ b/src/SQLProvider.Runtime/Providers.MsSqlServer.Ssdt.fs
@@ -172,7 +172,7 @@ module MSSqlServerSsdt =
         | None ->
             match Map.tryFind (UDDTName dataType) uddts with
             | Some (UDDTInheritedType x) -> tryFindMappingOrVariant uddts x
-            | None -> (typeMappingsByName.TryFind "SQL_VARIANT").Value
+            | None -> typeMappingsByName["SQL_VARIANT"]
 
     let ssdtTableToTable (tbl: SsdtTable) =
         { Schema = tbl.Schema ; Name = tbl.Name ; Type =  if tbl.IsView then "view" else "base table" }

--- a/src/SQLProvider.Runtime/Ssdt.DacpacParser.fs
+++ b/src/SQLProvider.Runtime/Ssdt.DacpacParser.fs
@@ -87,7 +87,9 @@ and SsdtDescriptionItem = {
     ColumnName: string voption
     Description: string
 }
-and SsdtUserDefinedDataType = Map<string, string>
+and SsdtUserDefinedDataType = Map<UDDTName, UDDTInheritedType>
+and UDDTName = UDDTName of string
+and UDDTInheritedType = UDDTInheritedType of string
 
 module RegexParsers =
     open System.Text.RegularExpressions
@@ -390,7 +392,7 @@ let parseXml(xml: string) =
 
     let parseUserDefinedDataType (udts: XmlNode) =
         let name = udts |> att "Name"
-        let name = name |> RegexParsers.splitFullName |> fun parsed -> String.Join(".", parsed) |> fun n -> n.ToUpper()
+        let name = name |> RegexParsers.splitFullName |> fun parsed -> String.Join(".", parsed) |> fun n -> n.ToUpper() |> UDDTName
         let inheritedType =
             udts
             |> nodes "x:Relationship"
@@ -400,6 +402,7 @@ let parseXml(xml: string) =
             |> RegexParsers.splitFullName
             |> fun parsed -> String.Join(".", parsed)
             |> fun t -> t.ToUpper()
+            |> UDDTInheritedType
         (name, inheritedType)
 
     let userDefinedDataTypes =

--- a/src/SQLProvider.Runtime/Ssdt.DacpacParser.fs
+++ b/src/SQLProvider.Runtime/Ssdt.DacpacParser.fs
@@ -390,11 +390,11 @@ let parseXml(xml: string) =
             Description = description
         }
 
-    let parseUserDefinedDataType (udts: XmlNode) =
-        let name = udts |> att "Name"
+    let parseUserDefinedDataType (uddts: XmlNode) =
+        let name = uddts |> att "Name"
         let name = name |> RegexParsers.splitFullName |> fun parsed -> String.Join(".", parsed) |> fun n -> n.ToUpper() |> UDDTName
         let inheritedType =
-            udts
+            uddts
             |> nodes "x:Relationship"
             |> Seq.find (fun n -> n |> att "Name" = "Type")
             |> node "x:Entry/x:References"

--- a/tests/SqlProvider.Core.Tests/MsSqlSsdt/MsSqlSsdt.Tests/AdventureWorks_SSDT/AdventureWorks_SSDT.sqlproj
+++ b/tests/SqlProvider.Core.Tests/MsSqlSsdt/MsSqlSsdt.Tests/AdventureWorks_SSDT/AdventureWorks_SSDT.sqlproj
@@ -16,12 +16,13 @@
     <ModelCollation>1033, CI</ModelCollation>
     <DefaultFileStructure>BySchemaAndSchemaType</DefaultFileStructure>
     <DeployToDatabase>True</DeployToDatabase>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <TargetLanguage>CS</TargetLanguage>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <SqlServerVerification>False</SqlServerVerification>
     <IncludeCompositeObjects>True</IncludeCompositeObjects>
     <TargetDatabaseSet>True</TargetDatabaseSet>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>bin\Release\</OutputPath>

--- a/tests/SqlProvider.Core.Tests/MsSqlSsdt/MsSqlSsdt.Tests/MsSqlSsdt.Tests.fsproj
+++ b/tests/SqlProvider.Core.Tests/MsSqlSsdt/MsSqlSsdt.Tests/MsSqlSsdt.Tests.fsproj
@@ -22,6 +22,7 @@
     <Compile Include="Dacpac\UnzipTests.fs" />
     <Compile Include="Dacpac\ParseSchemaTests.fs" />
     <Compile Include="Dacpac\TypeAnnotationTests.fs" />
+    <Compile Include="UserDefinedDataTypes.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/tests/SqlProvider.Core.Tests/MsSqlSsdt/MsSqlSsdt.Tests/MsSqlSsdt.Tests.fsproj
+++ b/tests/SqlProvider.Core.Tests/MsSqlSsdt/MsSqlSsdt.Tests/MsSqlSsdt.Tests.fsproj
@@ -22,11 +22,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="AdventureWorks_SSDT.dacpac" />
+    <None Include="AdventureWorks_SSDT.dacpac">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <Compile Include="..\..\..\..\src\SQLProvider.Runtime\Ssdt.DacpacParser.fs" Link="Ssdt.DacpacParser.fs" />
     <Compile Include="UnzipTests.fs" />
     <Compile Include="ParseSchemaTests.fs" />
     <Compile Include="TypeAnnotationTests.fs" />
+    <Compile Include="UserDefinedDataTypes.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/tests/SqlProvider.Core.Tests/MsSqlSsdt/MsSqlSsdt.Tests/UserDefinedDataTypes.fs
+++ b/tests/SqlProvider.Core.Tests/MsSqlSsdt/MsSqlSsdt.Tests/UserDefinedDataTypes.fs
@@ -1,0 +1,18 @@
+module UserDefinedDataTypesTests
+open FSharp.Data.Sql
+open FSharp.Data.Sql.Schema
+
+[<Literal>]
+let AdventureWorks = @"Server=localhost\SQLEXPRESS;Database=AdventureWorksLT2019;Trusted_Connection=True;"
+
+[<Literal>]
+let SsdtPath = __SOURCE_DIRECTORY__ + "/AdventureWorks_SSDT/bin/Debug/AdventureWorks_SSDT.dacpac"
+
+type DB = SqlDataProvider<Common.DatabaseProviderTypes.MSSQLSERVER_SSDT, SsdtPath = SsdtPath>
+
+let ctx = DB.GetDataContext(AdventureWorks)
+
+let ``Flag UDDT should be equals to a System.Boolean`` =
+    let entity = ctx.SalesLt.SalesOrderHeader.Create()
+    if (entity.OnlineOrderFlag.GetType().FullName) <> "System.Boolean"
+    then failwith "Failed test condition for user defined data type: Flag UDDT should be equals to a System.Boolean."


### PR DESCRIPTION
This is a merge from the latest master.

Not solving the dacpac-file not existing yet as the `build.fsx` BuildTests task should call building the dacpac before calling `Fake.DotNet.DotNet.exec id "build" "SQLProvider.Tests.sln -c Debug  --no-dependencies" |> ignore`

....but there the sqlproj building might have some compatibility issues, see the other comment in the PR.
